### PR TITLE
Reexport bevy_renet

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -118,9 +118,9 @@ pub fn client_connection_config() -> RenetConnectionConfig {
 }
 
 fn new_renet_client() -> RenetClient {
-    let server_addr = "127.0.0.1:5001".parse().unwrap();
+    let server_addr = "127.0.0.1:5000".parse().unwrap();
 
-    let server_socket = UdpSocket::bind("127.0.0.1:5001").unwrap();
+    let socket = UdpSocket::bind("127.0.0.1:5001").unwrap();
 
     let connection_config = client_connection_config();
 
@@ -138,14 +138,14 @@ fn new_renet_client() -> RenetClient {
 
     let client = RenetClient::new(
         current_time,
-        server_socket,
+        socket,
         client_id,
         connection_config,
         authentication,
     )
     .unwrap();
 
-    info!("Constructed new RenetClient with server addr {server_addr} and client addr");
+    println!("Constructed new RenetClient with server addr {server_addr} and client addr");
     client
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub mod server;
 pub mod client;
 
+pub use bevy_renet;
 
 pub const PRIVATE_KEY: &[u8; NETCODE_KEY_BYTES] = b"an example very very secret key."; // 32-bytes
 pub const PROTOCOL_ID: u64 = 7;


### PR DESCRIPTION
Since we are using a fork for bevy_renet it's easier to reexport it to use on the client.
Also make sure we use the correct server addr